### PR TITLE
Update .forceignore to avoid deploy problem

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -5,3 +5,6 @@ package.xml
 # LWC configuration files
 **/jsconfig.json
 **/.eslintrc.json
+
+# LWC Jest
+**/__tests__/**


### PR DESCRIPTION
I'm train myself on this trailhead:
https://trailhead.salesforce.com/en/content/learn/projects/lwc-build-flexible-apps/hello-world?trail_id=build-lightning-web-components&trailmix_creator_id=cdicurz&trailmix_slug=get-started

And found problem during the deploy phase, apparently caused from this old version of the file the `.forceignore`.
In the test template of the `lwc` component there are a problematic import:

```javascript
import { createElement } from 'lwc';
```

In more recent guides i see that you had add this ignore, also your `Salesforce CLI` automatically add it, so....

I hope this solution can help others
